### PR TITLE
feat(semantic-release-ghcr): Support specifying build platforms

### DIFF
--- a/semantic-release-ghcr/action.yml
+++ b/semantic-release-ghcr/action.yml
@@ -22,6 +22,10 @@ inputs:
     required: false
     description: Suffix of the image name after repository name, e.g. ghcr.io/myorg/myrepo</this/is/the/suffix>. Include a starting / please!
     default: ''
+  platforms:
+    required: false
+    description: Comma-separated list of target platforms of the build
+    default: 'linux/amd64,linux/arm64'
   
 outputs:
   new-release-published:
@@ -66,6 +70,7 @@ runs:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         push: true
+        platforms: ${{ inputs.platforms }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: |


### PR DESCRIPTION
Support specifying target platforms for the build, with default to Linux amd64 e arm64.