### PR TITLE
chore: Fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/ict-github-actions/security/code-scanning/1](https://github.com/pagopa/ict-github-actions/security/code-scanning/1)

In general, the fix is to declare an explicit `permissions:` block for this workflow or for the specific `release` job, instead of relying on repository defaults. This constrains what the `GITHUB_TOKEN` can do and documents the intended privileges.

The best targeted fix here is to add a `permissions:` block under the `release` job (so it only affects this job). `semantic-release` typically needs to push tags and create GitHub releases, which requires `contents: write`. Many common semantic‑release setups also update GitHub issues or PRs (e.g., via plugins), which would require `issues: write` and/or `pull-requests: write`. Since we must not change functionality, we should choose a conservative but realistic set of permissions that covers typical semantic‑release usage: `contents: write`, `issues: write`, and `pull-requests: write`. If you know your configuration only touches releases/tags, you could later pare this down to just `contents: write`, but including `issues` and `pull-requests` keeps compatibility with common configurations.

Concretely, in `.github/workflows/release.yml`, under `jobs: release: name: Release`, insert a `permissions:` section, indented correctly, before `runs-on:`. No imports or additional files are needed; this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
