### PR TITLE
chore: Fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,6 +11,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/ict-github-actions/security/code-scanning/3](https://github.com/pagopa/ict-github-actions/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block either at the workflow root (applies to all jobs) or under the specific job that uses `GITHUB_TOKEN`. This block should grant only the minimum scopes needed, typically `contents: read` and possibly `pull-requests: read` for a validation action like this.

The single best way here, without changing functionality, is to add a job‑level `permissions` block under `jobs.main`. The `amannn/action-semantic-pull-request` action reads PR and commit metadata and reports a check result; it does not need to push code or modify repository contents. A conservative minimal set is:
- `contents: read` (standard baseline)
- `pull-requests: read` (to read PR titles and metadata)

If the action were to comment on the PR or modify it, `pull-requests: write` would be needed, but since that is not evident from the snippet, we keep it at `read` to avoid silently expanding capabilities.

Concretely, in `.github/workflows/pr-title.yml`, after `runs-on: ubuntu-24.04` in the `main` job, insert:

```yaml
    permissions:
      contents: read
      pull-requests: read
```

No imports or additional methods are required because this is a YAML workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
